### PR TITLE
fixed issue #5. Will now generate days in the whole month.

### DIFF
--- a/src/timeforge/helpers.py
+++ b/src/timeforge/helpers.py
@@ -64,11 +64,23 @@ class Month_Dataset:
     def add_work(self, job, date, start_time, end_time, pause, work_hours):
         self.days.append(Day(job, date, start_time, end_time, pause, work_hours))
 
+
+    def year_is_leap_year(year) -> bool:
+        if ((year%4 == 0 and year % 100 != 0) or year%400==0):
+            return True
+        return False
+    
+    def days_of_month(self,month:int,year:int) -> int:
+        if month == 2 and self.year_is_leap_year(year):
+            return 29
+        number_of_days_in_month = [31,28,31,30,31,30,31,31,30,31,30,31]
+        return number_of_days_in_month[month-1]
+
     def generate_content(self, job):
 
         def suggest_day_of_month():
             while True:
-                day = random.randint(1,28)  # random day from the 1st to the 28th of a month (February is the shortest month)
+                day = random.randint(1,self.days_of_month(self.month,self.year))  # random day from the 1st to the last day of the month
                 d = date(self.year, self.month, day)
                 if d.weekday() <= 4 and not d in self.feiertage:
                     return d


### PR DESCRIPTION
Will now generate days in the whole month. Rather than just the first 28 days.

# Description

Fixed the issue by using a list to look up the number of days in the current month and returning 29 if the current month is February in a leap year

Fixes #5  (issue)
Adds # (feature)
Improves # https://github.com/MitchiLaser/timeforge/blame/9db1d9735990e077b076d71e5cc2d730cc910a82/src/timeforge/helpers.py#L71 (Code-segment / functionality)

## Type of change

Please select options that are relevant:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactoring (no change at all noticeable for the users)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change is / includes / requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove a fix is effective or that a feature works
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Any changes in dependent python modules has been updated in the files `pyproject.toml` and `requirements.txt
